### PR TITLE
[FastLeafDecayTweak] Remove unnecessary async feature and optimize the code

### DIFF
--- a/compiler/pom.xml
+++ b/compiler/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>Tweakin</artifactId>
         <groupId>com.github.sachin</groupId>
-        <version>3.8.3</version>
+        <version>3.8.6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -63,19 +63,19 @@
         <dependency>
             <groupId>com.github.sachin</groupId>
             <artifactId>core</artifactId>
-            <version>3.8.3</version>
+            <version>3.8.6</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.github.sachin</groupId>
             <artifactId>nms1_18</artifactId>
-            <version>3.8.3</version>
+            <version>3.8.6</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.github.sachin</groupId>
             <artifactId>nms1_17</artifactId>
-            <version>3.8.3</version>
+            <version>3.8.6</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/compiler/pom.xml
+++ b/compiler/pom.xml
@@ -23,7 +23,7 @@
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>3.2.0</version>
                 <configuration>
-                    <finalName>Tweakin-3.8.5</finalName>
+                    <finalName>Tweakin-3.8.6</finalName>
                 </configuration>
             </plugin>
             <plugin>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>Tweakin</artifactId>
         <groupId>com.github.sachin</groupId>
-        <version>3.8.3</version>
+        <version>3.8.6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>

--- a/core/src/main/java/com/github/sachin/tweakin/modules/fastleafdecay/FastLeafDecayTweak.java
+++ b/core/src/main/java/com/github/sachin/tweakin/modules/fastleafdecay/FastLeafDecayTweak.java
@@ -52,13 +52,11 @@ public class FastLeafDecayTweak extends BaseTweak implements Listener {
         for (Location location : leavesLocations) {
             Bukkit.getScheduler().scheduleSyncDelayedTask(getPlugin(), () -> {
                 Block block = location.getBlock();
-                if (block.getType().name().endsWith("LEAVES")) {
                     LeavesDecayEvent event = new LeavesDecayEventForChecking(block);
                     Bukkit.getPluginManager().callEvent(event);
                     if (!event.isCancelled()) {
                         block.breakNaturally();
                     }
-                }
             }, ThreadLocalRandom.current().nextInt(duration));
         }
     }

--- a/core/src/main/java/com/github/sachin/tweakin/modules/fastleafdecay/FastLeafDecayTweak.java
+++ b/core/src/main/java/com/github/sachin/tweakin/modules/fastleafdecay/FastLeafDecayTweak.java
@@ -52,11 +52,11 @@ public class FastLeafDecayTweak extends BaseTweak implements Listener {
         for (Location location : leavesLocations) {
             Bukkit.getScheduler().scheduleSyncDelayedTask(getPlugin(), () -> {
                 Block block = location.getBlock();
-                    LeavesDecayEvent event = new LeavesDecayEventForChecking(block);
-                    Bukkit.getPluginManager().callEvent(event);
-                    if (!event.isCancelled()) {
-                        block.breakNaturally();
-                    }
+                LeavesDecayEvent event = new LeavesDecayEventForChecking(block);
+                Bukkit.getPluginManager().callEvent(event);
+                if (!event.isCancelled()) {
+                    block.breakNaturally();
+                }
             }, ThreadLocalRandom.current().nextInt(duration));
         }
     }

--- a/core/src/main/java/com/github/sachin/tweakin/modules/fastleafdecay/FastLeafDecayTweak.java
+++ b/core/src/main/java/com/github/sachin/tweakin/modules/fastleafdecay/FastLeafDecayTweak.java
@@ -11,7 +11,6 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.LeavesDecayEvent;
-import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -85,7 +84,7 @@ public class FastLeafDecayTweak extends BaseTweak implements Listener {
     }
 
     private static class LeavesDecayEventForChecking extends LeavesDecayEvent {
-        public LeavesDecayEventForChecking(@NotNull Block block) {
+        public LeavesDecayEventForChecking(Block block) {
             super(block);
         }
     }

--- a/core/src/main/java/com/github/sachin/tweakin/modules/fastleafdecay/FastLeafDecayTweak.java
+++ b/core/src/main/java/com/github/sachin/tweakin/modules/fastleafdecay/FastLeafDecayTweak.java
@@ -11,96 +11,69 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.LeavesDecayEvent;
-import org.bukkit.scheduler.BukkitRunnable;
+import org.jetbrains.annotations.NotNull;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
 
-public class FastLeafDecayTweak extends BaseTweak implements Listener{
+public class FastLeafDecayTweak extends BaseTweak implements Listener {
 
     private int duration;
-    private final Set<LeavesDecayEvent> fastDecayEvents = new HashSet<>();
 
 
     public FastLeafDecayTweak(Tweakin plugin) {
         super(plugin, "fast-leaf-decay");
     }
 
+
     @Override
     public void reload() {
         super.reload();
-        this.duration = getConfig().getInt("duration",10) * 20;
+        this.duration = getConfig().getInt("duration", 10) * 20;
+        //Remove unused option
+        if (getConfig().isSet("use-async")) {
+            getConfig().set("use-async", null);
+        }
     }
 
-    @EventHandler(priority = EventPriority.HIGHEST,ignoreCancelled = true)
-    public void onLeafDecay(LeavesDecayEvent e){
-        if(fastDecayEvents.remove(e)) return;
-        if(getBlackListWorlds().contains(e.getBlock().getWorld().getName())) return;
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    public void onLeafDecay(LeavesDecayEvent e) {
+        if (e instanceof LeavesDecayEventForChecking) return;
+        if (getBlackListWorlds().contains(e.getBlock().getWorld().getName())) return;
         e.setCancelled(true);
         Block block = e.getBlock();
-        if(getConfig().getBoolean("use-async")){
-            new BukkitRunnable(){
-                @Override
-                public void run() {
-                    List<Location> locs = getNearbyBlocks(block.getLocation(), 10,true);
-                    removeLeaves(locs);
-                }
-            }.runTaskAsynchronously(getPlugin());
-        }
-        else{
-            List<Location> locs = getNearbyBlocks(block.getLocation(), 10,false);
-            removeLeaves(locs);
-        }
-        
+        removeLeaves(block.getLocation());
+
     }
-    
-    private void removeLeaves(List<Location> locs){
-        for (Location location : locs) {
-    
-            
+
+    private void removeLeaves(Location startLocation) {
+        List<Location> leavesLocations = getNearbyLeaves(startLocation, 10);
+        for (Location location : leavesLocations) {
             Bukkit.getScheduler().scheduleSyncDelayedTask(getPlugin(), () -> {
                 Block block = location.getBlock();
-                if(block.getType().name().endsWith("LEAVES")){
-                    LeavesDecayEvent event = new LeavesDecayEvent(block);
-                    fastDecayEvents.add(event);
+                if (block.getType().name().endsWith("LEAVES")) {
+                    LeavesDecayEvent event = new LeavesDecayEventForChecking(block);
                     Bukkit.getPluginManager().callEvent(event);
-                    if(!event.isCancelled()){
+                    if (!event.isCancelled()) {
                         block.breakNaturally();
-                        locs.remove(location);
                     }
                 }
-            },new Random().nextInt(duration));
-    
-    
+            }, ThreadLocalRandom.current().nextInt(duration));
         }
     }
 
-    public List<Location> getNearbyBlocks(Location location, int radius,boolean isAsync) {
+    public List<Location> getNearbyLeaves(Location location, int radius) {
         // List<Block> blocks = new ArrayList<Block>();
         List<Location> locs = new ArrayList<>();
-        for(int x = location.getBlockX() - radius; x <= location.getBlockX() + radius; x++) {
-            for(int y = location.getBlockY() - radius; y <= location.getBlockY() + radius; y++) {
-                for(int z = location.getBlockZ() - radius; z <= location.getBlockZ() + radius; z++) {
+        for (int x = location.getBlockX() - radius; x <= location.getBlockX() + radius; x++) {
+            for (int y = location.getBlockY() - radius; y <= location.getBlockY() + radius; y++) {
+                for (int z = location.getBlockZ() - radius; z <= location.getBlockZ() + radius; z++) {
                     Block block = location.getWorld().getBlockAt(x, y, z);
-                    if(!block.getType().isAir()){
-                        if(isAsync){
-                            Bukkit.getScheduler().scheduleSyncDelayedTask(plugin, ()-> {
-                                if(isLeaf(block)){
-                                    
-                                    Leaves leaves = (Leaves) block.getBlockData();
-                                    if(!leaves.isPersistent() && leaves.getDistance() > 6 && !locs.contains(block.getLocation())){
-                                        locs.add(block.getLocation());
-                                    }
-                                }
-                            });
-                        }
-                        else{
-                            if(isLeaf(block)){
-                                    
-                                Leaves leaves = (Leaves) block.getBlockData();
-                                if(!leaves.isPersistent() && leaves.getDistance() > 6 && !locs.contains(block.getLocation())){
-                                    locs.add(block.getLocation());
-                                }
-                            }
+                    if (!block.getType().isAir() && isLeaf(block)) {
+                        Leaves leaves = (Leaves) block.getBlockData();
+                        if (!leaves.isPersistent() && leaves.getDistance() > 6 && !locs.contains(block.getLocation())) {
+                            locs.add(block.getLocation());
                         }
                     }
                 }
@@ -109,8 +82,14 @@ public class FastLeafDecayTweak extends BaseTweak implements Listener{
         return locs;
     }
 
-    private boolean isLeaf(Block block){
+    private boolean isLeaf(Block block) {
         return Tag.LEAVES.isTagged(block.getType());
     }
-    
+
+    private static class LeavesDecayEventForChecking extends LeavesDecayEvent {
+        public LeavesDecayEventForChecking(@NotNull Block block) {
+            super(block);
+        }
+    }
+
 }

--- a/core/src/main/resources/config.yml
+++ b/core/src/main/resources/config.yml
@@ -110,8 +110,6 @@ fast-leaf-decay:
   black-list-worlds: []
   # maximum duration leaves will stay (in seconds)
   duration: 10
-  # weather or not to run checks for nearby leaf blocks in async fashion
-  use-async: true
 
 # Ladders are slightly tweaked to improve your laddering experience:
   # Right clicking a ladder with another one will place it, allowing you to drop ladders down without risking falling to your death.

--- a/core/src/main/resources/plugin.yml
+++ b/core/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: Tweakin
-version: 3.8.5
+version: 3.8.6
 main: com.github.sachin.tweakin.Tweakin
 api-version: 1.16
 api: []

--- a/nms1_17/pom.xml
+++ b/nms1_17/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>Tweakin</artifactId>
         <groupId>com.github.sachin</groupId>
-        <version>3.8.3</version>
+        <version>3.8.6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>
@@ -47,7 +47,7 @@
         <dependency>
             <groupId>com.github.sachin</groupId>
             <artifactId>core</artifactId>
-            <version>3.8.3</version>
+            <version>3.8.6</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/nms1_18/pom.xml
+++ b/nms1_18/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>Tweakin</artifactId>
         <groupId>com.github.sachin</groupId>
-        <version>3.8.3</version>
+        <version>3.8.6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -84,7 +84,7 @@
         <dependency>
             <groupId>com.github.sachin</groupId>
             <artifactId>core</artifactId>
-            <version>3.8.3</version>
+            <version>3.8.6</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.sachin</groupId>
     <artifactId>Tweakin</artifactId>
-    <version>3.8.3</version>
+    <version>3.8.6</version>
     <modules>
         <module>nms1_17</module>
         <module>nms1_18</module>


### PR DESCRIPTION
Changes:

1. Remove unnecessary async feature, basically all operations is done on the main thread, so it's no needed and may run out of thread resources. (I meet the following errors and server crashed by this repeatedly)
```Craft Async Scheduler Management Thread
java.lang.OutOfMemoryError: unable to create native thread: possibly out of memory or process/resource limits reached
```
2. Remove unnecessary fastDecayEvents and replace with more efficient `instanceof` checking.
3. Renamed misleading method name (`getNearbyBlock` -> `getNearbyLeaves`)
4. Merge if statements and remove duplicated checking statements
5. Use ThreadLocalRandom instead of creating a new Random instance every time.